### PR TITLE
Make bricksync compatible with current BrickStore files

### DIFF
--- a/bsx.c
+++ b/bsx.c
@@ -854,7 +854,7 @@ int bsxLoadInventory( bsxInventory *inv, char *path )
 
   /* Locate sections */
   ordersection = ccStrFindStrSkip( inv->xmldata, "<Order>" );
-  inventorysection = ccStrFindStrSkip( inv->xmldata, "<Inventory>" );
+  inventorysection = ccStrFindStrSkip( inv->xmldata, "<Inventory" );
 
   /* Cut sections */
   if( !( ccStrFindStr( ordersection, "</Order>" ) ) )


### PR DESCRIPTION
BrickStore 2021.x adds a Currency attribute on the Inventory element.
A proper XML parser wouldn't care, but this here just matches complete tag strings.

PLEASE TEST THIS FIRST before accepting. It should do the right thing, but I have no idea how to test it :)



